### PR TITLE
Fix code scanning alert no. 1: Reflected cross-site scripting

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "description": "",
   "dependencies": {
     "cors": "^2.8.5",
-    "express": "^4.21.0"
+    "express": "^4.21.0",
+    "escape-html": "^1.0.3"
   },
   "devDependencies": {
     "nodemon": "^3.1.7"

--- a/server.js
+++ b/server.js
@@ -48,8 +48,9 @@ app.get('/grab', (req, res) => { // captura los datos enviados por el cliente
     }
 });
 
+const escapeHtml = require('escape-html');
 app.get('/loot', (req, res) => { // envía los datos guardados al cliente
-    res.send(texto);
+    res.send(escapeHtml(texto));
 });
 
 app.get('/clear', (req, res) => { // limpia el archivo de salida


### PR DESCRIPTION
Fixes [https://github.com/Xelofrost/datagrabber/security/code-scanning/1](https://github.com/Xelofrost/datagrabber/security/code-scanning/1)

To fix the reflected cross-site scripting vulnerability, we need to ensure that any user-provided data is properly escaped before being included in the HTTP response. This can be achieved by using a library like `escape-html` to sanitize the input.

- **General fix:** Use contextual output encoding/escaping before writing user input to the response.
- **Detailed fix:** Import the `escape-html` library and use it to escape the `texto` variable before sending it in the response.
- **Specific changes:** Modify the `/loot` endpoint to escape the `texto` variable.
- **Requirements:** Import the `escape-html` library.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
